### PR TITLE
bump versions

### DIFF
--- a/apitools/build.gradle
+++ b/apitools/build.gradle
@@ -25,7 +25,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion compile_sdk_version
@@ -32,7 +31,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
     implementation "androidx.core:core-ktx:$core_ktx_version"
     testImplementation "junit:junit:$junit_version"

--- a/bills/build.gradle
+++ b/bills/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: "kotlin-kapt"
 apply plugin: 'com.github.dcendents.android-maven'
 
@@ -43,7 +42,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.core:core-ktx:$core_ktx_version"
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
     testImplementation "junit:junit:$junit_version"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.room_version = '2.3.0'
     ext.core_ktx_version = '1.6.0'
     ext.coroutines_test_version = '1.3.3'
-    ext.material_version = '1.3.0-alpha03'
+    ext.material_version = '1.5.0-alpha01'
     // https://github.com/square/retrofit/blob/master/CHANGELOG.md 2.6.4 is last retrofit version for sdk 19
     ext.retrofit_version = '2.6.4'
     // https://square.github.io/okhttp/changelog_3x/ 3.12.13 is last okhttp version for sdk 19

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.room_version = '2.3.0'
     ext.core_ktx_version = '1.6.0'
     ext.coroutines_test_version = '1.3.3'
-    ext.material_version = '1.5.0-alpha01'
+    ext.material_version = '1.4.0'
     // https://github.com/square/retrofit/blob/master/CHANGELOG.md 2.6.4 is last retrofit version for sdk 19
     ext.retrofit_version = '2.6.4'
     // https://square.github.io/okhttp/changelog_3x/ 3.12.13 is last okhttp version for sdk 19
@@ -38,7 +38,7 @@ buildscript {
     ext.android_plugin_version = "3.1.4"
     ext.timber_version = "4.7.1"
     ext.truetime_version = "3.4"
-    ext.fragment_ktx_version = "1.4.0-alpha05"
+    ext.fragment_ktx_version = "1.3.6"
     ext.firebase_firestore_ktx = "23.0.3"
     ext.constraint_layout = "2.1.0"
     ext.slf4j_version = "1.7.25"

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.compile_sdk_version = 28
+    ext.compile_sdk_version = 30
     ext.target_sdk_version = 28
     ext.min_sdk_version = 16
-    ext.kotlin_version = '1.5.0'
+    ext.kotlin_version = '1.5.21'
     ext.room_version = '2.3.0'
-    ext.core_ktx_version = '1.3.2'
+    ext.core_ktx_version = '1.6.0'
     ext.coroutines_test_version = '1.3.3'
     ext.material_version = '1.3.0-alpha03'
     // https://github.com/square/retrofit/blob/master/CHANGELOG.md 2.6.4 is last retrofit version for sdk 19
@@ -16,29 +16,32 @@ buildscript {
     ext.mockito_kotlin_version = '2.2.0'
     ext.firebase_version = "17.2.2"
     ext.scribe_version = "3.4.1"
-    ext.junit_version = "4.13.1"
-    ext.junit_ext_version = "1.1.2"
+    ext.junit_version = "4.13.2"
+    ext.junit_ext_version = "1.1.3"
     ext.butter_knife_version = "10.2.1"
     ext.rx_android_version = "2.1.1"
     ext.rx_java_version = "2.2.0"
     ext.mockito_version = "3.3.0"
-    ext.lifecycle_version = "2.2.0"
+    ext.lifecycle_version = "2.3.1"
     ext.livedata_version = "2.3.1"
-    ext.coroutines_version = "1.3.9"
-    ext.gson_version = '2.8.6'
+    ext.coroutines_version = "1.4.1"
+    ext.gson_version = '2.8.7'
     ext.robolectric_version = "4.3.1"
     ext.log4j_version = "1.2.13"
     ext.hamcrest_version = "1.3"
     ext.maven_ant_tasks_version = "2.1.3"
-    ext.androidx_appcompat_version = '1.2.0'
+    ext.androidx_appcompat_version = '1.3.1'
     ext.androidx_recyclerview = '1.1.0'
-    ext.androidx_test_runner = "1.3.0"
-    ext.androidx_test_espresso = "3.3.0"
+    ext.androidx_test_runner = "1.4.0"
+    ext.androidx_test_espresso = "3.4.0"
     ext.androidx_test_annotation = "1.1.0"
     ext.android_plugin_version = "3.1.4"
     ext.timber_version = "4.7.1"
     ext.truetime_version = "3.4"
-    ext.fragment_ktx_version = "1.3.0-beta02"
+    ext.fragment_ktx_version = "1.4.0-alpha05"
+    ext.firebase_firestore_ktx = "23.0.3"
+    ext.constraint_layout = "2.1.0"
+    ext.slf4j_version = "1.7.25"
 
     repositories {
         google()
@@ -46,7 +49,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
 

--- a/common_utils/build.gradle
+++ b/common_utils/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.github.dcendents.android-maven'
 
 group='com.github.Storyous'
@@ -49,7 +48,7 @@ dependencies {
     androidTestImplementation "androidx.test:runner:$androidx_test_runner"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidx_test_espresso"
 
-    implementation "androidx.recyclerview:recyclerview:1.1.0"
+    implementation "androidx.recyclerview:recyclerview:1.2.1"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "com.github.instacart.truetime-android:library:$truetime_version"
@@ -57,7 +56,7 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxandroid:$rx_android_version"
 
     implementation 'com.github.tony19:logback-android:2.0.0'
-    implementation 'org.slf4j:slf4j-api:1.7.24'
+    implementation "org.slf4j:slf4j-api:$slf4j_version"
 
     // Logging
     implementation "com.jakewharton.timber:timber:$timber_version"

--- a/contacts/build.gradle
+++ b/contacts/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.github.dcendents.android-maven'
 
 group='com.github.Storyous'
@@ -30,7 +29,6 @@ dependencies {
     implementation project(path: ':firebase')
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
     implementation "androidx.core:core-ktx:$core_ktx_version"
 
@@ -46,7 +44,7 @@ dependencies {
     implementation "com.jakewharton.timber:timber:$timber_version"
 
     // Firestore
-    implementation 'com.google.firebase:firebase-firestore-ktx:22.0.0'
+    implementation "com.google.firebase:firebase-firestore-ktx:$firebase_firestore_ktx"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$coroutines_version"
 
     // JWT

--- a/delivery/build.gradle
+++ b/delivery/build.gradle
@@ -56,7 +56,6 @@ dependencies {
     implementation project(path: ':common_utils')
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
     implementation "androidx.core:core-ktx:$core_ktx_version"
     implementation "androidx.fragment:fragment-ktx:$fragment_ktx_version"
@@ -66,13 +65,13 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidx_test_espresso"
     implementation 'com.android.support:support-v13:28.0.0'
 
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation "androidx.constraintlayout:constraintlayout:$constraint_layout"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
 
-    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
-    kapt "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
-    annotationProcessor "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version")
+    implementation("androidx.lifecycle:lifecycle-common-java8:$lifecycle_version")
 
     implementation "androidx.recyclerview:recyclerview:1.2.1"
 

--- a/delivery/src/main/java/com/storyous/delivery/common/DeliveryDetailFragment.kt
+++ b/delivery/src/main/java/com/storyous/delivery/common/DeliveryDetailFragment.kt
@@ -215,6 +215,7 @@ class DeliveryDetailFragment : Fragment(R.layout.fragment_delivery_detail) {
         timesAdapter.items = times
     }
 
+    @Suppress("unused")
     private fun updateOrderNumber(provider: String, orderId: String) {
         order_number.text = DeliveryModel.getOrderInfo(provider) { resId, param ->
             getString(resId, "$param")

--- a/delivery/src/main/java/com/storyous/delivery/common/DeliverySettingsFragment.kt
+++ b/delivery/src/main/java/com/storyous/delivery/common/DeliverySettingsFragment.kt
@@ -101,7 +101,7 @@ class DeliverySettingsFragment : Fragment(R.layout.fragment_delivery_settings), 
 
     override fun collapse() {
         with(view as ConstraintLayout) {
-            if (!contains(flow)) {
+            if (flow != null && !contains(flow)) {
                 addView(flow)
             }
             constraintCollapsed.applyTo(this)

--- a/delivery/src/main/java/com/storyous/delivery/common/translations.kt
+++ b/delivery/src/main/java/com/storyous/delivery/common/translations.kt
@@ -23,7 +23,7 @@ fun ContextStringResProvider(context: Context) = object : StringResProvider {
 
 fun DeliveryOrder.getLegacyDeliveryTime(provider: StringResProvider): String {
     val prefix = if (deliveryOnTime == true) R.string.time_at else R.string.time_till
-    val date = DateUtils.HM.format(deliveryTime)
+    val date = deliveryTime?.let { DateUtils.HM.format(it) }
     return provider.getString(prefix, date)
 }
 

--- a/delivery/src/main/res/layout/fragment_delivery_settings.xml
+++ b/delivery/src/main/res/layout/fragment_delivery_settings.xml
@@ -133,12 +133,13 @@
         android:orientation="horizontal"
         app:layout_constraintGuide_begin="@dimen/settings_height_expanded" />
 
-    <com.google.android.material.progressindicator.ProgressIndicator
+    <com.google.android.material.progressindicator.CircularProgressIndicator
         android:id="@+id/progress"
-        style="@style/Widget.MaterialComponents.ProgressIndicator.Circular.Indeterminate"
+        style="@style/Widget.MaterialComponents.CircularProgressIndicator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"
+        android:indeterminate="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/firebase/build.gradle
+++ b/firebase/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'kotlin-android-extensions'
     id 'com.github.dcendents.android-maven'
 }
 
@@ -37,7 +36,6 @@ android {
 
 dependencies {
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
     implementation "androidx.core:core-ktx:$core_ktx_version"
 
@@ -55,7 +53,7 @@ dependencies {
     implementation "com.jakewharton.timber:timber:$timber_version"
 
     // Firestore
-    implementation 'com.google.firebase:firebase-firestore-ktx:22.0.0'
+    implementation "com.google.firebase:firebase-firestore-ktx:$firebase_firestore_ktx"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$coroutines_version"
 
     // JWT


### PR DESCRIPTION
compile sdk 28 -> 30
kotlin 1.5.0 -> 1.5.21
core ktx 1.3.2 -> 1.6.0
junit 4.13.1 -> 4.13.2
junit ext 1.1.2 -> 1.1.3
lifecycle 2.2.0 -> 2.3.1
coroutines 1.3.9 -> 1.4.1
gson 2.8.6 -> 2.8.7
androidx appcompat 1.2.0 -> 1.3.1
androidx test runner 1.3.0 -> 1.4.0
androidx test espresso 3.3.0 -> 3.4.0
fragment ktx 1.3.0-beta02 -> 1.3.6
firebase firestore ktx 22.0.0 -> 23.0.3
constraint layout 2.0.4 -> 2.1.0
slf4j 1.7.24 -> 1.7.25
gradle tools 4.0.1 -> 4.0.2
material 1.3.0-alpha03 -> 1.4.0